### PR TITLE
Update README.md with typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can get the executable in any of the following ways:
 1. `macism` will output the current input source
 2. `macism SOME_INPUT_SOURCE_ID` will select to `SOME_INPUT_SOURCE_ID`.
 3. `macism SOME_INPUT_SOURCE_ID uSECONDS` will select to `SOME_INPUT_SOURCE_ID`. 
-  If switch from none-CJKV to CJKV, will sleep uSECONDS (default to 20000)
+  If switch from none-CJKV to CJKV, will sleep uSECONDS (default to 12000)
   micro seconds.
 4. Add an extra option `--noKeyboardOnly` to command pattern *#2* and *#3* will 
   also enable none-keyboard input sources.


### PR DESCRIPTION
According to the source code [L59](https://github.com/laishulu/macism/blob/61a521a0e7b11b5b3782ceac164aebd1dc7f3e69/macism.swift#L59), it seems the 20000 should be 12000.