### PR TITLE
Defer InputSourceManager.initialize() until after --version handling

### DIFF
--- a/macism.swift
+++ b/macism.swift
@@ -3,15 +3,15 @@ import Foundation
 @main
 struct MacISM {
     static func main() {
-        // Initialize input sources
-        InputSourceManager.initialize()
-
         if CommandLine.arguments.contains(where: { arg in
             arg.caseInsensitiveCompare("--version") == .orderedSame
         }) {
             print("v3.0.10")
             return
         }
+
+        // Initialize input sources
+        InputSourceManager.initialize()
 
         if CommandLine.arguments.count == 1 {
             let currentSource = InputSourceManager.getCurrentSource()


### PR DESCRIPTION
This patch moves the input source initialization to occur after processing the --version flag. When a user invokes `macism --version`, the program now prints the version and exits without initializing input sources.


## Motivation

Previously, `InputSourceManager.initialize()` was called unconditionally at startup. This caused unnecessary work even for trivial commands like `--version`. Deferring initialization speeds up `--version` and reduces the chance of initialization-related side effects in sandbox environments (e.g. Nix) that only check the version.