### PR TITLE
fix: characters may remain in the pre-editing area #29

### DIFF
--- a/InputSourceManager.swift
+++ b/InputSourceManager.swift
@@ -16,16 +16,6 @@ class InputSource: Equatable {
         return tisInputSource.id
     }
 
-    var isCJKV: Bool {
-        if let lang = tisInputSource.sourceLanguages.first {
-            return lang == "ko" ||
-                   lang == "ja" ||
-                   lang == "vi" ||
-                   lang.hasPrefix("zh")
-        }
-        return false
-    }
-
     init(tisInputSource: TISInputSource) {
         self.tisInputSource = tisInputSource
     }
@@ -33,11 +23,6 @@ class InputSource: Equatable {
     func select() {
         let currentSource = InputSourceManager.getCurrentSource()
         if currentSource.id == self.id {
-            return
-        }
-        // fcitx and non-CJKV don't need special treat
-        if !self.isCJKV {
-            TISSelectInputSource(tisInputSource)
             return
         }
 

--- a/macism.swift
+++ b/macism.swift
@@ -6,7 +6,7 @@ struct MacISM {
         if CommandLine.arguments.contains(where: { arg in
             arg.caseInsensitiveCompare("--version") == .orderedSame
         }) {
-            print("v3.0.10")
+            print("v3.0.11")
             return
         }
 


### PR DESCRIPTION
## Summary
- remove CJKV-only branch when switching input sources, and always follow the same switching flow
- avoid leaving characters in the pre-editing area in the pre-editing phase
- bump version output to v3.0.11

## Test
- manual verification by switching input methods while composing text