### PR TITLE
Allow user-configurable wait time on CLI (fixes #31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,25 @@ macism SOME_INPUT_SOURCE_ID
 ```
 macism SOME_INPUT_SOURCE_ID 0
 ```
+#### Switch with a custom wait time (advanced)
+The third argument is the wait time in milliseconds for the workaround
+(`TemporaryWindow`). The built-in default is `1`ms, which works on most older
+macOS versions. On **macOS 26 (Tahoe)** the 1ms default can be too short —
+Squirrel and other CJK IMEs may not fully take over before you start typing,
+causing the first 1–2 characters to leak as the previous IME. Pass a higher
+wait time to make the switch reliable:
+```
+macism SOME_INPUT_SOURCE_ID 100
+```
+Empirical numbers on macOS 26.4.1 (continuous switching with immediate typing):
+- `1` (default): ~30–50% race rate
+- `50`: ~5% race rate
+- `100`: stable in dozens of attempts
+- `150`: fully stable
+
+The total switch latency is roughly `cold-start + wait`, so pick the smallest
+value that is reliable for you.
+
 ## Thanks
 - [LuSrackhall](https://github.com/LuSrackhall) for his key insight in this
   [discussion](

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -52,6 +52,22 @@ macism SOME_INPUT_SOURCE_ID
 ```
 macism SOME_INPUT_SOURCE_ID 0
 ```
+#### 自定义 wait 时间（进阶）
+第三个参数是 workaround（`TemporaryWindow`）的等待时间（毫秒）。内置默认值是
+`1`ms，在大多数旧版 macOS 上够用。在 **macOS 26 (Tahoe)** 上，1ms 太短——
+鼠须管等 CJK 输入法还没完整接管事件流，开始打字时前 1–2 个字符会按上一个
+输入法漏出。传入更大的 wait 值可以稳定切换：
+```
+macism SOME_INPUT_SOURCE_ID 100
+```
+在 macOS 26.4.1 实测（连续切换并立即打字）：
+- `1`（默认）：~30–50% race
+- `50`：~5% race
+- `100`：几十次测试均稳定
+- `150`：完全稳定
+
+总切换延迟约为 `cold-start + wait`，建议取在你的环境下能稳定工作的最小值。
+
 ## 致谢
 - [LuSrackhall](https://github.com/LuSrackhall) 在此[讨
   论](https://github.com/rime/squirrel/issues/866#issuecomment-2800561092)中提供

--- a/macism.swift
+++ b/macism.swift
@@ -6,7 +6,7 @@ struct MacISM {
         if CommandLine.arguments.contains(where: { arg in
             arg.caseInsensitiveCompare("--version") == .orderedSame
         }) {
-            print("v3.0.10")
+            print("v3.1.0")
             return
         }
 
@@ -37,12 +37,13 @@ struct MacISM {
                 return
             }
 
-            // Set wait time if provided
+            // Set wait time if provided (any integer accepted).
+            // 0  = skip the TemporaryWindow workaround entirely.
+            // <0 = use built-in default (1ms).
+            // >0 = wait that many milliseconds. Higher values (e.g. 100ms) are
+            //      recommended on macOS 26 (Tahoe) to avoid the CJK race.
             if filteredArgs.count == 3, let waitTime = Int(filteredArgs[2]) {
-                // ignore waitTime of none-zero
-                if waitTime == 0 {
-                    InputSourceManager.waitTimeMs = waitTime
-                }
+                InputSourceManager.waitTimeMs = waitTime
             }
 
             dstSource.select()


### PR DESCRIPTION
## Summary

Resolves #31 — the CLI silently ignored any non-zero `waitTime` argument, so the `TemporaryWindow` workaround was effectively capped at the built-in 1ms default. This is too short for the CJK race on macOS 26 (Tahoe).

This PR removes the `if waitTime == 0` filter so any integer the user passes is honored:

| value | behavior | changed? |
|---|---|---|
| `0` | skip the workaround entirely | unchanged |
| `<0` (or omitted) | fall back to the 1ms default | unchanged |
| `>0` | wait that many milliseconds | **new — was silently ignored before** |

## Compatibility

Default behavior is unchanged — only adds capability when an explicit value is passed. No existing scripts should break.

## Why this matters

On macOS 26.4.1 (Tahoe), continuous EN → CJK switching with immediate typing shows:

| `waitTime` | race rate |
|---|---|
| `1` (current default) | ~30–50% — first 1–2 chars leak as previous IME |
| `50` | ~5% |
| `100` | stable in dozens of attempts |
| `150` | fully stable |

Related external context (all hit the same Apple `TISSelectInputSource` cross-process bug):
- [runjuu/InputSourcePro#85](https://github.com/runjuu/InputSourcePro/issues/85) — same race, author submitted Apple minimal repro
- Karabiner-Elements docs warn against `select_input_source` for CJK
- zcbenz: "[has been a problem for] 十多年" (10+ years)

## Changes

- `macism.swift`: removed the `if waitTime == 0` filter; clarifying comment block; version → `v3.1.0`
- `README.md` / `README.zh-CN.md`: new "Switch with a custom wait time (advanced)" section with measured race rates + Tahoe note

## Test plan

- [x] `make all` builds clean (Swift 6, arm64, macOS 26.4.1)
- [x] `macism --version` → `v3.1.0`
- [x] `macism com.apple.keylayout.US 0` → switches, ~50ms total
- [x] `macism im.rime.inputmethod.Squirrel.Hans 1` → ~360ms (≈ cold-start + 1ms wait, matches old behavior)
- [x] `macism im.rime.inputmethod.Squirrel.Hans 200` → ~500ms (≈ cold-start + 200ms wait — confirms the parameter is now actually honored)
- [x] Manual: in Ghostty + Squirrel on Tahoe, `... 100` eliminates the first-character race that `... 1` exhibits