### PR TITLE
Raise default wait time from 1ms to 150ms (v3.1.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,19 +56,23 @@ macism SOME_INPUT_SOURCE_ID 0
 ```
 #### Switch with a custom wait time (advanced)
 The third argument is the wait time in milliseconds for the workaround
-(`TemporaryWindow`). The built-in default is `1`ms, which works on most older
-macOS versions. On **macOS 26 (Tahoe)** the 1ms default can be too short —
-Squirrel and other CJK IMEs may not fully take over before you start typing,
-causing the first 1–2 characters to leak as the previous IME. Pass a higher
-wait time to make the switch reliable:
+(`TemporaryWindow`). The built-in default is `150`ms — empirically the smallest
+fully-stable value for the CJK race on **macOS 26 (Tahoe)**. With a shorter
+wait, Squirrel and other CJK IMEs may not fully take over before you start
+typing, causing the first 1–2 characters to leak as the previous IME.
+
+Older macOS versions only needed ~1ms; the conservative default means existing
+users don't silently break after an OS upgrade, at the cost of a slightly
+higher (usually imperceptible) switch latency. If you are on an older macOS and
+want it snappier, pass a smaller value:
 ```
-macism SOME_INPUT_SOURCE_ID 100
+macism SOME_INPUT_SOURCE_ID 50
 ```
 Empirical numbers on macOS 26.4.1 (continuous switching with immediate typing):
-- `1` (default): ~30–50% race rate
+- `1`: ~30–50% race rate
 - `50`: ~5% race rate
 - `100`: stable in dozens of attempts
-- `150`: fully stable
+- `150` (default): fully stable
 
 The total switch latency is roughly `cold-start + wait`, so pick the smallest
 value that is reliable for you.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,17 +54,19 @@ macism SOME_INPUT_SOURCE_ID 0
 ```
 #### 自定义 wait 时间（进阶）
 第三个参数是 workaround（`TemporaryWindow`）的等待时间（毫秒）。内置默认值是
-`1`ms，在大多数旧版 macOS 上够用。在 **macOS 26 (Tahoe)** 上，1ms 太短——
-鼠须管等 CJK 输入法还没完整接管事件流，开始打字时前 1–2 个字符会按上一个
-输入法漏出。传入更大的 wait 值可以稳定切换：
+`150`ms——在 **macOS 26 (Tahoe)** 上实测能完全稳定的最小值。wait 太短时鼠须管
+等 CJK 输入法还没完整接管事件流，开始打字时前 1–2 个字符会按上一个输入法漏出。
+
+旧版 macOS 只需要 ~1ms；保守的默认值是为了让老用户在 OS 升级后不会无声 break，
+代价是切换延迟略高（通常感知不到）。如果你在旧版 macOS 上想更快，可以传更小的值：
 ```
-macism SOME_INPUT_SOURCE_ID 100
+macism SOME_INPUT_SOURCE_ID 50
 ```
 在 macOS 26.4.1 实测（连续切换并立即打字）：
-- `1`（默认）：~30–50% race
+- `1`：~30–50% race
 - `50`：~5% race
 - `100`：几十次测试均稳定
-- `150`：完全稳定
+- `150`（默认）：完全稳定
 
 总切换延迟约为 `cold-start + wait`，建议取在你的环境下能稳定工作的最小值。
 

--- a/WindowUtils.swift
+++ b/WindowUtils.swift
@@ -30,8 +30,13 @@ func showTemporaryInputWindow(waitTimeMs: Int) {
     if waitTimeMs == 0 {
         return
     }
-    // Handle wait time and app termination
-    let waitTime = waitTimeMs < 0 ? 1 : waitTimeMs
+    // Handle wait time and app termination.
+    // Default (when no explicit value is passed) is 150ms: empirically the
+    // smallest fully-stable value for the CJK race on macOS 26 (Tahoe). Older
+    // macOS only needed ~1ms, but defaulting high means existing users don't
+    // silently break after an OS upgrade. Pass an explicit smaller value to
+    // trade reliability for latency.
+    let waitTime = waitTimeMs < 0 ? 150 : waitTimeMs
 
     let app = NSApplication.shared
     app.setActivationPolicy(.accessory)

--- a/macism.swift
+++ b/macism.swift
@@ -6,7 +6,7 @@ struct MacISM {
         if CommandLine.arguments.contains(where: { arg in
             arg.caseInsensitiveCompare("--version") == .orderedSame
         }) {
-            print("v3.1.0")
+            print("v3.1.1")
             return
         }
 
@@ -39,9 +39,10 @@ struct MacISM {
 
             // Set wait time if provided (any integer accepted).
             // 0  = skip the TemporaryWindow workaround entirely.
-            // <0 = use built-in default (1ms).
-            // >0 = wait that many milliseconds. Higher values (e.g. 100ms) are
-            //      recommended on macOS 26 (Tahoe) to avoid the CJK race.
+            // <0 = use built-in default (150ms).
+            // >0 = wait that many milliseconds. Lower it (e.g. 50) to trade
+            //      reliability for latency on older macOS where the CJK race
+            //      is less likely.
             if filteredArgs.count == 3, let waitTime = Int(filteredArgs[2]) {
                 InputSourceManager.waitTimeMs = waitTime
             }


### PR DESCRIPTION
## Summary

Follow-up to #32 / #31. Changes the built-in default wait for the `TemporaryWindow` workaround from **1ms → 150ms**.

#32 made the wait time configurable, but most existing v3 users call `macism` *without* a wait argument and rely on the default. With the old 1ms default they silently break after upgrading to macOS 26 (Tahoe) — the CJK switch races and the first 1–2 typed chars leak as the previous IME.

Defaulting to 150ms (the smallest empirically fully-stable value, per #31) fixes those users transparently.

## Trade-off

| | before | after |
|---|---|---|
| Tahoe users, no wait arg | broken (race) | fixed |
| Older-macOS users, no wait arg | ~1ms | ~150ms (usually imperceptible) |
| Anyone passing explicit value | honored | honored (unchanged) |
| Non-CJK switches | unaffected | unaffected (workaround skipped) |

Older-macOS users who want it snappier can pass an explicit smaller value, e.g. `macism SOME_INPUT_SOURCE_ID 50`.

## Changes

- `WindowUtils.swift`: default `1` → `150` (with explanatory comment)
- `macism.swift`: updated comment; version → `v3.1.1`
- `README.md` / `README.zh-CN.md`: document the new default and the older-macOS path

## Test plan

- [x] `make all` builds clean (macOS 26.4.1, arm64)
- [x] `macism --version` → `v3.1.1`
- [x] `macism IM` (no wait arg) → ~0.50s total (≈ cold-start + 150ms), was ~0.36s with the old 1ms default — confirms new default applies
- [x] `macism IM 0` → ~0.05s (workaround skipped, unchanged)
- [x] Manual: in Ghostty + Squirrel on Tahoe, no-arg switch no longer leaks the first character

Discussed and agreed in #31.